### PR TITLE
Update link_stats_table()

### DIFF
--- a/R/assignment_tables.R
+++ b/R/assignment_tables.R
@@ -94,7 +94,7 @@ link_stats_table <- function(links, volume, count, group_field = NULL,
       # character. don't need to worry
       bind_rows(lt, tot) %>%
         mutate(
-          `Percent Deviation` = pct_error(`Observed Flow`, `Model Flow`)
+          `Percent Deviation` = pct_error(`Model Flow`, `Observed Flow`)
         )
     )
 


### PR DESCRIPTION
Common convention is that the traffic count (observed flow)
is the reference number. Swapped the fields in the percent
deviation calculation.